### PR TITLE
fix: honor per-subnet map_public_ip_on_launch in the subnet locals

### DIFF
--- a/subnet.tf
+++ b/subnet.tf
@@ -9,9 +9,10 @@ locals {
   public_subnets = flatten([
     for subnet in var.public_subnets : [
       for index, cidr_block in subnet.cidr_blocks : {
-        cidr_block        = "${subnet.network}.${cidr_block}"
-        ipv6_cidr_block   = "${subnet.ipv6_network}${element(subnet.ipv6_cidr_blocks, index)}"
-        availability_zone = element(var.availability_zones, index)
+        cidr_block              = "${subnet.network}.${cidr_block}"
+        ipv6_cidr_block         = "${subnet.ipv6_network}${element(subnet.ipv6_cidr_blocks, index)}"
+        availability_zone       = element(var.availability_zones, index)
+        map_public_ip_on_launch = try(subnet.map_public_ip_on_launch, true)
       }
     ]
   ])
@@ -19,9 +20,10 @@ locals {
   private_subnets = flatten([
     for subnet in var.private_subnets : [
       for index, cidr_block in subnet.cidr_blocks : {
-        cidr_block        = "${subnet.network}.${cidr_block}"
-        ipv6_cidr_block   = "${subnet.ipv6_network}${element(subnet.ipv6_cidr_blocks, index)}"
-        availability_zone = element(var.availability_zones, index)
+        cidr_block              = "${subnet.network}.${cidr_block}"
+        ipv6_cidr_block         = "${subnet.ipv6_network}${element(subnet.ipv6_cidr_blocks, index)}"
+        availability_zone       = element(var.availability_zones, index)
+        map_public_ip_on_launch = try(subnet.map_public_ip_on_launch, false)
       }
     ]
   ])

--- a/tests/map_public_ip_on_launch.tftest.hcl
+++ b/tests/map_public_ip_on_launch.tftest.hcl
@@ -1,0 +1,109 @@
+############################################
+#  subnet/tests/map_public_ip_on_launch.tftest.hcl  #
+############################################
+
+# Plan-only tests: no AWS credentials and no API calls are needed.
+# Run with `terraform init && terraform test`.
+
+provider "aws" {
+  region                      = "us-east-1"
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+}
+
+variables {
+  name               = "test-subnet"
+  vpc_id             = "vpc-0123456789abcdef0"
+  availability_zones = ["us-east-1a"]
+}
+
+run "public_subnet_uses_the_caller_supplied_override" {
+  command = plan
+
+  variables {
+    public_route_table_ids = ["rtb-0123456789abcdef0"]
+    public_subnets = [
+      {
+        network          = "10.0"
+        cidr_blocks      = ["0.0/24"]
+        ipv6_network     = "2600:1f18:0000:"
+        ipv6_cidr_blocks = ["81::/64"]
+
+        map_public_ip_on_launch = false
+      }
+    ]
+  }
+
+  assert {
+    condition     = aws_subnet.public_subnet["us-east-1a-10.0.0.0/24"].map_public_ip_on_launch == false
+    error_message = "public subnet ignored map_public_ip_on_launch = false and auto-assigned a public IP"
+  }
+}
+
+run "public_subnet_still_defaults_to_true" {
+  command = plan
+
+  variables {
+    public_route_table_ids = ["rtb-0123456789abcdef0"]
+    public_subnets = [
+      {
+        network          = "10.0"
+        cidr_blocks      = ["0.0/24"]
+        ipv6_network     = "2600:1f18:0000:"
+        ipv6_cidr_blocks = ["81::/64"]
+      }
+    ]
+  }
+
+  assert {
+    condition     = aws_subnet.public_subnet["us-east-1a-10.0.0.0/24"].map_public_ip_on_launch == true
+    error_message = "public subnet no longer defaults to map_public_ip_on_launch = true"
+  }
+}
+
+run "private_subnet_uses_the_caller_supplied_override" {
+  command = plan
+
+  variables {
+    private_route_table_ids = ["rtb-0123456789abcdef0"]
+    private_subnets = [
+      {
+        network          = "10.0"
+        cidr_blocks      = ["106.0/24"]
+        ipv6_network     = "2600:1f18:0000:"
+        ipv6_cidr_blocks = ["91::/64"]
+
+        map_public_ip_on_launch = true
+      }
+    ]
+  }
+
+  assert {
+    condition     = aws_subnet.private_subnet["us-east-1a-10.0.106.0/24"].map_public_ip_on_launch == true
+    error_message = "private subnet ignored map_public_ip_on_launch = true"
+  }
+}
+
+run "private_subnet_still_defaults_to_false" {
+  command = plan
+
+  variables {
+    private_route_table_ids = ["rtb-0123456789abcdef0"]
+    private_subnets = [
+      {
+        network          = "10.0"
+        cidr_blocks      = ["106.0/24"]
+        ipv6_network     = "2600:1f18:0000:"
+        ipv6_cidr_blocks = ["91::/64"]
+      }
+    ]
+  }
+
+  assert {
+    condition     = aws_subnet.private_subnet["us-east-1a-10.0.106.0/24"].map_public_ip_on_launch == false
+    error_message = "private subnet no longer defaults to map_public_ip_on_launch = false"
+  }
+}


### PR DESCRIPTION
This PR proposes honoring a caller's per-subnet `map_public_ip_on_launch` value, which the module reads but currently cannot see. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/384. You can sign in with your GitHub ID to claim ownership of the project.

## What is wrong

Both subnet resources already offer a per-subnet override:

```hcl
map_public_ip_on_launch = lookup(each.value, "map_public_ip_on_launch", true)   # public_subnet
map_public_ip_on_launch = lookup(each.value, "map_public_ip_on_launch", false)  # private_subnet
```

`each.value` comes from `local.public_subnets` / `local.private_subnets`, and those `flatten` blocks only emit `cidr_block`, `ipv6_cidr_block` and `availability_zone`. The key the `lookup` asks for therefore never exists, the default always wins, and a value set on a `public_subnets` / `private_subnets` entry is silently dropped. The practical effect is that a public subnet from this module always auto-assigns a public IPv4 address and there is no way to turn that off — which is both a security-posture decision and, since AWS started charging for public IPv4 in February 2024, a billing one.

## Reproducing on `main`

Against `main` at `539d9be`, with a root module that sets the override explicitly:

```hcl
module "subnet" {
  source                 = "./terraform-aws-subnet"
  name                   = "fixture"
  vpc_id                 = "vpc-0123456789abcdef0"
  availability_zones     = ["us-east-1a"]
  public_route_table_ids = ["rtb-0123456789abcdef0"]

  public_subnets = [
    {
      network                 = "10.0"
      cidr_blocks             = ["0.0/24"]
      ipv6_network            = "2600:1f18:0000:"
      ipv6_cidr_blocks        = ["81::/64"]
      map_public_ip_on_launch = false
    }
  ]
}
```

`terraform plan` returns:

```
  # module.subnet.aws_subnet.public_subnet["us-east-1a-10.0.0.0/24"] will be created
      + map_public_ip_on_launch                        = true
```

The same fixture on this branch plans `map_public_ip_on_launch = false`. (The fixture passes `ipv6_network` / `ipv6_cidr_blocks` because `main` still dereferences them unconditionally; that is a separate matter and #8 is already on it.)

## The change

Two lines in the `locals` block — the caller's value is carried into the flattened object, keeping each resource's existing default as the fallback, so `terraform plan` on an unchanged root module produces exactly the same subnets as before:

```hcl
map_public_ip_on_launch = try(subnet.map_public_ip_on_launch, true)   # public_subnets
map_public_ip_on_launch = try(subnet.map_public_ip_on_launch, false)  # private_subnets
```

The existing `lookup(each.value, ...)` calls in the resources are untouched and now resolve.

## Verification

`tests/map_public_ip_on_launch.tftest.hcl` adds four plan-only `terraform test` runs — override and default, for public and private subnets. They need no AWS credentials and make no API calls, so `terraform init && terraform test` runs them anywhere.

On this branch all four pass. Reverting only the two `locals` lines and re-running the same tests gives the failure that motivated the change, while both default cases stay green:

```
  run "public_subnet_uses_the_caller_supplied_override"... fail
    │ aws_subnet.public_subnet["us-east-1a-10.0.0.0/24"].map_public_ip_on_launch is true
  run "public_subnet_still_defaults_to_true"... pass
  run "private_subnet_uses_the_caller_supplied_override"... fail
    │ aws_subnet.private_subnet["us-east-1a-10.0.106.0/24"].map_public_ip_on_launch is false
  run "private_subnet_still_defaults_to_false"... pass

Failure! 2 passed, 2 failed.
```

`terraform fmt -check -recursive` and `terraform validate` were run on `main` before the change and on this branch after it; both are clean in each case, so nothing regressed.

I deliberately left `README.md` and `EXAMPLE.md` alone, since #4, #7 and #8 are all open against them and I would rather not hand you a conflict. If you would like the option documented, `map_public_ip_on_launch = false` added to the public-subnet example in `EXAMPLE.md` covers it, and I am happy to push that here.

## How this was managed

This work was tracked as [a single story](https://eastagiletracker.com/projects/384/stories/260263) on [a board](https://eastagiletracker.com/projects/384) imported from this repository's own issues and pull requests — 8 stories in all, with the pull requests carried across as labelled stories.

![board](https://raw.githubusercontent.com/eastagiletracker/terraform-aws-subnet/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
